### PR TITLE
Move python-igraph from extras_require to install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,12 +23,8 @@ setuptools.setup(
         'pandas',
         'networkx',
         'requests',
+        'python-igraph',
     ],
-    extras_require={
-        'python-igraph': (
-            'python-igraph'
-        ),
-    },
     classifiers=[
         'Intended Audience :: Science/Research',
         'Intended Audience :: Developers',


### PR DESCRIPTION
I tried to import py4cytoscape and confirmed that this is needed.