### PR TITLE
In the Verify Cytoscape connection code fragment made file path platform agnostic

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -72,11 +72,12 @@ To verify that ``py4cytoscape`` is properly installed and able to communicate wi
 Cytoscape, execute the following in a Python Console or Jupyter Notebook
 (after starting Cytoscape)::
 
+   import os
    import py4cytoscape as py4
    dir(py4)
    py4.cytoscape_ping()
    py4.cytoscape_version_info()
-   py4.import_network_from_file("tests\data\galfiltered.sif")
+   py4.import_network_from_file(os.path.join('tests','data' ,'galfiltered.sif'))
 
 This will import ``py4cytoscape`` into the Python namespace, print a (long) list
 of ``py4cytoscape`` entrypoints, and then demonstrate a connection to Cytoscape

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -72,12 +72,11 @@ To verify that ``py4cytoscape`` is properly installed and able to communicate wi
 Cytoscape, execute the following in a Python Console or Jupyter Notebook
 (after starting Cytoscape)::
 
-   import os
    import py4cytoscape as py4
    dir(py4)
    py4.cytoscape_ping()
    py4.cytoscape_version_info()
-   py4.import_network_from_file(os.path.join('tests','data' ,'galfiltered.sif'))
+   py4.import_network_from_file("tests/data/galfiltered.sif")
 
 This will import ``py4cytoscape`` into the Python namespace, print a (long) list
 of ``py4cytoscape`` entrypoints, and then demonstrate a connection to Cytoscape


### PR DESCRIPTION
Hi,
This pull request has a minor change in the INSTALL.rst documentation. 

In Verify Cytoscape connection code framgnet, I replaced the hardcoded path `tests\data\galfiltered.sif' with an `os.path.join` call cause `\` fails on a MacOS. 

The `os.path.join` "should" (please check on windows) add the correct delimiter for the platform it is running on. 