### PR TITLE
Fixed broken link to the tutorials page on readthedocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ For an explanation of ``py4cytoscape`` installation and testing, see the [INSTAL
 ## How run a simple workflow
 
 For a quick tutorial on how to build a workflow in Python and using ``py4cytoscape``, see
-https://py4cytoscape.readthedocs.io/en/latest/tutorial.html.
+https://py4cytoscape.readthedocs.io/en/latest/tutorials/index.html.
 You can try ``py4cytoscape`` with a web browser only, without installing anything in your local environment.
 
 ## How to configure logging


### PR DESCRIPTION
Under the **How run a simple workflow** section in the `README.md` file, fixed a broken link to the tutorials page.